### PR TITLE
Enabling SAML as part of OSS

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -67,7 +67,7 @@ RUN git clone --depth=1 https://github.com/Yubico/libfido2.git -b 1.12.0 && \
 # 4. Fast, language-dependent dependencies
 # 5. Multi-stage layer copies
 
-FROM ubuntu:18.04 AS buildbox
+FROM ubuntu:20.04 AS buildbox
 
 COPY locale.gen /etc/locale.gen
 COPY profile /etc/profile

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -2904,9 +2904,10 @@ func (a *ServerWithRoles) UpsertSAMLConnector(ctx context.Context, connector typ
 	if err := a.authConnectorAction(apidefaults.Namespace, types.KindSAML, types.VerbUpdate); err != nil {
 		return trace.Wrap(err)
 	}
-	if modules.GetModules().Features().SAML == false {
+	// Commenting this to enable SAML as part of OSS
+	/*if modules.GetModules().Features().SAML == false {
 		return trace.AccessDenied("SAML is only available in enterprise subscriptions")
-	}
+	}*/
 	return a.authServer.UpsertSAMLConnector(ctx, connector)
 }
 


### PR DESCRIPTION
1. Enabling SAML as part of OSS.
2. _make image_ to create docker image.